### PR TITLE
Oauth2

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,24 +70,6 @@ boot.executeInParallel([
     });
   });
 
-  // Authenticate OAuth2 requests by enabling authorized access scopes.
-  app.use((request, response, next) => {
-    // Example scopes:
-    // - `'hostname': 'host.name'` allows managing the cluster host 'host.name'.
-    request.scope = {};
-
-    let clientId = request.query.client_id || null;
-    let clientSecret = request.query.client_secret || null;
-    if (clientId && clientSecret) {
-      let hostname = hosts.authenticate(clientId, clientSecret);
-      if (hostname) {
-        request.scope.hostname = hostname;
-      }
-    }
-
-    next();
-  });
-
   // Mount the Janitor API.
   selfapi(app, '/api', api);
 

--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -32,17 +32,21 @@ exports.get = function (hostname) {
   return hosts[hostname || 'localhost'];
 };
 
-// Find a Docker hostname that matches the given OAuth2 credentials.
-exports.authenticate = function (clientId, clientSecret) {
-  let hosts = db.get('hosts');
+// Find a Docker hostname that fully matches the request's OAuth2 credentials.
+exports.authenticate = function (request) {
+  let { client_id = null, client_secret = null } = request.query;
+  if (!client_id || !client_secret) {
+    return null;
+  }
 
+  let hosts = db.get('hosts');
   for (let hostname in hosts) {
     let host = hosts[hostname];
     if (!host || !host.oauth2client) {
       continue;
     }
     let { id, secret } = host.oauth2client;
-    if (String(clientId) === id && String(clientSecret) === secret) {
+    if (String(client_id) === id && String(client_secret) === secret) {
       return hostname;
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "stop": "if [ -e janitor.pid -a -n \"$(ps h $(cat janitor.pid))\" ] ; then kill $(cat janitor.pid) && printf \"[$(date -uIs)] Background process stopped (PID $(cat janitor.pid)).\\n\" ; fi ; rm -f janitor.pid"
   },
   "dependencies": {
-    "@jankeromnes/camp": "~16.2.10",
+    "@jankeromnes/camp": "~16.2.13",
     "dockerode": "~2.3.1",
     "email-login": "~1.0.1",
     "fast-json-patch": "~1.1.4",


### PR DESCRIPTION
@bnjbvr Following your advice, I stopped trying to make OAuth2 authentication (client ID + client secret) a common middleware that intercepts all requests, because this authentication will only be accepted for a few specific requests anyway. Instead, I will just authenticate OAuth2 clients where it's actually useful.

Note: In Janitor-land, the OAuth2 "service" (where user accounts and API live) is the main server, and OAuth2 "clients" are secondary cluster hosts (where users access some resources, but an OAuth2 handshake with the service is required to authenticate them).

PTAL 😀