### PR TITLE
Authenticate access token, scope and user in OAuth2 requests to the Janitor API.

### DIFF
--- a/api/hosts-api.js
+++ b/api/hosts-api.js
@@ -341,12 +341,12 @@ hostAPI.get('/:container/:port', {
   description: 'Get information about a given Docker container port.',
 
   handler: (request, response) => {
-    let { user, oauth2access } = request;
-    let { hostname } = request.query;
-    if (!user && oauth2access && oauth2access.hostname === hostname) {
-      let { scopes } = oauth2access;
-      if (scopes.includes('user') || scopes.includes('user:ports')) {
-        user = oauth2access.user;
+    let { user, oauth2scope } = request;
+    const { hostname } = request.query;
+    if (!user && oauth2scope && oauth2scope.hostname === hostname) {
+      const { scopes } = oauth2scope;
+      if (scopes.has('user') || scopes.has('user:ports')) {
+        user = oauth2scope.user;
       }
     }
 
@@ -356,22 +356,22 @@ hostAPI.get('/:container/:port', {
       return;
     }
 
-    let { container } = request.query;
+    const { container } = request.query;
     if (container.length < 16 || !/^[0-9a-f]+$/.test(container)) {
       response.statusCode = 400; // Bad Request
       response.json({ error: 'Invalid container ID' });
       return;
     }
 
-    let machine = machines.getMachineByContainer(user, hostname, container);
+    const machine = machines.getMachineByContainer(user, hostname, container);
     if (!machine) {
       response.statusCode = 404;
       response.json({ error: 'Container not found' });
       return;
     }
 
-    let port = String(request.query.port);
-    for (let projectPort in machine.docker.ports) {
+    const port = String(request.query.port);
+    for (const projectPort in machine.docker.ports) {
       if (projectPort === port) {
         response.json(machine.docker.ports[projectPort]);
         return;

--- a/api/hosts-api.js
+++ b/api/hosts-api.js
@@ -341,7 +341,15 @@ hostAPI.get('/:container/:port', {
   description: 'Get information about a given Docker container port.',
 
   handler: (request, response) => {
-    let { user } = request;
+    let { user, oauth2access } = request;
+    let { hostname } = request.query;
+    if (!user && oauth2access && oauth2access.hostname === hostname) {
+      let { scopes } = oauth2access;
+      if (scopes.includes('user') || scopes.includes('user:ports')) {
+        user = oauth2access.user;
+      }
+    }
+
     if (!user) {
       response.statusCode = 403; // Forbidden
       response.json({ error: 'Unauthorized' });
@@ -355,7 +363,6 @@ hostAPI.get('/:container/:port', {
       return;
     }
 
-    let { hostname } = request.query;
     let machine = machines.getMachineByContainer(user, hostname, container);
     if (!machine) {
       response.statusCode = 404;

--- a/app.js
+++ b/app.js
@@ -72,13 +72,7 @@ boot.executeInParallel([
 
   // Authenticate OAuth2 requests with a server middleware.
   app.use((request, response, next) => {
-    let access = users.getOAuth2Access(request);
-    if (access) {
-      let { hostname, scope, user } = access;
-      let scopes = scope.split(',');
-      request.oauth2access = { hostname, scopes, user };
-    }
-
+    request.oauth2scope = users.getOAuth2ScopeWithUser(request);
     next();
   });
 

--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -156,7 +156,7 @@ exports.resetOAuth2ClientSecret = function (host, callback) {
 // Pre-authorize a host to make OAuth2 requests on behalf of a user.
 exports.issueOAuth2AuthorizationCode = function (request, callback) {
   let { client_id, scope, state, redirect_url = null } = request.query;
-  let hostname = exports.identify(client_id);
+  const hostname = exports.identify(client_id);
   if (!hostname) {
     callback(new Error('No such OAuth2 client ID: ' + client_id));
     return;
@@ -169,23 +169,25 @@ exports.issueOAuth2AuthorizationCode = function (request, callback) {
     return;
   }
 
-  let { user } = request;
+  const { user } = request;
   if (!user) {
     callback(new Error('No user to authorize OAuth2 host: ' + hostname));
     return;
   }
 
-  let grant = {
-    email: user.email,
-    scopes: scope.split(',').map(s => s.trim())
-  };
+  const scopes = parseScopes(scope);
+  if (!scopes) {
+    callback(new Error('Invalid OAuth2 scope: ' + scope));
+    return;
+  }
 
-  let onCode = (error, data) => {
+  const grant = { email: user.email, scopes };
+  const onCode = (error, data) => {
     if (error) {
       callback(error);
       return;
     }
-    let { code } = data;
+    const { code } = data;
     redirect_url += (redirect_url.includes('?') ? '&' : '?') +
       'code=' + encodeURIComponent(code) +
       '&state=' + encodeURIComponent(state);
@@ -197,28 +199,29 @@ exports.issueOAuth2AuthorizationCode = function (request, callback) {
 
 // Effectively allow a host to make OAuth2 requests on behalf of a user.
 exports.issueOAuth2AccessToken = function (request, callback) {
-  let { client_id, code, state } = request.query;
-  let hostname = exports.identify(client_id);
+  const { client_id, code, state } = request.query;
+  const hostname = exports.identify(client_id);
   if (!hostname) {
     callback(new Error('No such OAuth2 client ID: ' + client_id));
     return;
   }
 
-  let onToken = (error, data) => {
+  const onToken = (error, data) => {
     if (error) {
       callback(error);
       return;
     }
 
-    let { scope: grant, token, tokenHash } = data;
-    let authorization = {
+    const { scope: grant, token, tokenHash } = data;
+    const scope = stringifyScopes(grant.scopes);
+    const authorization = {
       client: client_id,
       date: Date.now(),
       email: grant.email,
-      scopes: grant.scopes
+      scope: scope
     };
 
-    let oauth2tokens = db.get('oauth2tokens');
+    const oauth2tokens = db.get('oauth2tokens');
     if (oauth2tokens[tokenHash]) {
       callback(new Error('OAuth2 token hash already exists: ' + tokenHash));
       return;
@@ -227,7 +230,6 @@ exports.issueOAuth2AccessToken = function (request, callback) {
     oauth2tokens[tokenHash] = authorization;
     db.save();
 
-    let scope = authorization.scopes.join(',');
     log(hostname, 'was granted access to', scope, 'by', authorization.email);
     callback(null, {
       access_token: token,
@@ -239,27 +241,57 @@ exports.issueOAuth2AccessToken = function (request, callback) {
   oauth2provider.generateAccessToken(client_id, code, state, onToken);
 };
 
-// Find the authorized scope of a request's OAuth2 access token.
-exports.authenticateOAuth2Request = function (request) {
+// Find the OAuth2 access scope authorized for a request's access token.
+exports.getOAuth2Scope = function (request) {
+  // Support query parameters like '?access_token=<token>'.
   let token = request.query.access_token || null;
-  if ('authorization' in request.headers) {
-    token = request.headers['authorization'].split(/\s+/)[1];
+  // Support HTTP headers like 'Authorization: Bearer <token>'.
+  if (!token && ('authorization' in request.headers)) {
+    token = request.headers.authorization.split(/\s+/)[1];
   }
 
   if (!token) {
     return null;
   }
 
-  let tokenHash = oauth2provider.hash(token);
-  let oauth2tokens = db.get('oauth2tokens');
-  let authorization = oauth2tokens[tokenHash];
+  // Verify what the provided token is authorized for.
+  const tokenHash = oauth2provider.hash(token);
+  const oauth2tokens = db.get('oauth2tokens');
+  const authorization = oauth2tokens[tokenHash];
   if (!authorization) {
     return null;
   }
 
-  let { client, email, scopes } = authorization;
-  let hostname = exports.identify(client);
-  let scope = scopes.join(',');
+  const { client, email, scope } = authorization;
+  const hostname = exports.identify(client);
+  if (!hostname) {
+    // The authorized OAuth2 client doesn't exist anymore.
+    delete oauth2tokens[tokenHash];
+    return null;
+  }
 
-  return { email, hostname, scope };
+  const scopes = parseScopes(scope);
+  if (!scopes) {
+    // The authorized scope is invalid.
+    delete oauth2tokens[tokenHash];
+    return null;
+  }
+
+  return { email, hostname, scopes };
 };
+
+// Parse a comma-separated String of OAuth2 scopes into a Set object.
+function parseScopes (scope) {
+  if (!scope) {
+    return null;
+  }
+
+  const array = String(scope).split(',').map(item => item.trim());
+  const scopes = new Set(array);
+  return scopes;
+}
+
+// Convert a Set of OAuth2 scopes back into a comma-separated String.
+function stringifyScopes (scopes) {
+  return Array.from(scopes).join(',');
+}

--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -238,3 +238,28 @@ exports.issueOAuth2AccessToken = function (request, callback) {
   // Attempt to generate an access token with hash.
   oauth2provider.generateAccessToken(client_id, code, state, onToken);
 };
+
+// Find the authorized scope of a request's OAuth2 access token.
+exports.authenticateOAuth2Request = function (request) {
+  let token = request.query.access_token || null;
+  if ('authorization' in request.headers) {
+    token = request.headers['authorization'].split(/\s+/)[1];
+  }
+
+  if (!token) {
+    return null;
+  }
+
+  let tokenHash = oauth2provider.hash(token);
+  let oauth2tokens = db.get('oauth2tokens');
+  let authorization = oauth2tokens[tokenHash];
+  if (!authorization) {
+    return null;
+  }
+
+  let { client, email, scopes } = authorization;
+  let hostname = exports.identify(client);
+  let scope = scopes.join(',');
+
+  return { email, hostname, scope };
+};

--- a/lib/users.js
+++ b/lib/users.js
@@ -3,6 +3,7 @@
 
 let certificates = require('./certificates');
 let db = require('./db');
+let hosts = require('./hosts');
 let log = require('./log');
 let metrics = require('./metrics');
 let sessions = require('./sessions');
@@ -13,7 +14,7 @@ let hostname = db.get('hostname', 'localhost');
 exports.get = function (request, callback) {
   sessions.get(request, (error, session, token) => {
     if (error) {
-      log('session', error);
+      log('[fail] session', error);
       callback(null);
       return;
     }
@@ -56,7 +57,20 @@ exports.isAdmin = function (user) {
   if (user && user.email && (user.email in db.get('admins'))) {
     return true;
   }
+
   return false;
+};
+
+// Find the user that authorized a given OAuth2 request, and its access scope.
+exports.getOAuth2Access = function (request) {
+  let authorization = hosts.authenticateOAuth2Request(request);
+  if (authorization) {
+    let { email, hostname, scope } = authorization;
+    let user = getUser(email);
+    return { hostname, scope, user };
+  }
+
+  return null;
 };
 
 // Reset a user's dedicated Janitor SSH key pair.
@@ -66,6 +80,7 @@ exports.resetSSHKeyPair = function (user) {
       log('error while creating ssh keypair', error);
       return;
     }
+
     user.keys.ssh.fingerprint = keypair.fingerprint;
     user.keys.ssh.privateKey = keypair.privateKey;
     user.keys.ssh.publicKey = keypair.publicKey;

--- a/lib/users.js
+++ b/lib/users.js
@@ -21,7 +21,7 @@ exports.get = function (request, callback) {
 
     if (session.emailVerified()) {
       // The user is properly logged in.
-      callback(getUser(session.email));
+      callback(getOrCreateUser(session.email));
       return;
     }
 
@@ -40,7 +40,7 @@ exports.get = function (request, callback) {
         return;
       }
       log(email, 'verified');
-      callback(getUser(email));
+      callback(getOrCreateUser(email));
     });
   });
 };
@@ -61,16 +61,16 @@ exports.isAdmin = function (user) {
   return false;
 };
 
-// Find the user that authorized a given OAuth2 request, and its access scope.
-exports.getOAuth2Access = function (request) {
-  let authorization = hosts.authenticateOAuth2Request(request);
-  if (authorization) {
-    let { email, hostname, scope } = authorization;
-    let user = getUser(email);
-    return { hostname, scope, user };
+// Find the OAuth2 access scope and authorizing user for a request.
+exports.getOAuth2ScopeWithUser = function (request) {
+  const authenticatedScope = hosts.getOAuth2Scope(request);
+  if (!authenticatedScope) {
+    return null;
   }
 
-  return null;
+  const { email, hostname, scopes } = authenticatedScope;
+  const user = getOrCreateUser(email);
+  return { hostname, scopes, user };
 };
 
 // Reset a user's dedicated Janitor SSH key pair.
@@ -177,7 +177,7 @@ exports.sendInviteEmail = function (email, callback) {
       }
 
       // Ensure we have a user for that email address.
-      let user = getUser(email);
+      let user = getOrCreateUser(email);
 
       // Remove this email from the waitlist.
       let waitlist = db.get('waitlist');
@@ -194,7 +194,7 @@ exports.sendInviteEmail = function (email, callback) {
 };
 
 // Find an existing user, or create a new one.
-function getUser (email) {
+function getOrCreateUser (email) {
   let users = db.get('users');
   let user = users[email];
 


### PR DESCRIPTION
Hi @bnjbvr, could you please take a look at this pull request when you have time?

Now that we can issue OAuth2 access tokens, we also need to make them useful for something. This pull request implements the authentication of access tokens, which, if successful, gives us an email (the user who authorized this access) and a scope (which limits the access that is granted).

It also changes the `/api/hosts/:hostname/:container/:port` API endpoint to accept authentication by OAuth2 access tokens, provided that the scope includes `user:ports` (or simply `user`, which is a super-scope for all `user:*` scopes).

Again, please don't worry too much about verifying the OAuth2 algorithm itself and its security, because I'll request a security audit of those anyway.

I'm mostly worried I might have made an obvious mistake, or made a bad decision somewhere. Also, I'm not too happy with the function names `users.getOAuth2Access()` and `hosts.authenticateOAuth2Request()`. Both return a bunch of things associated to a valid access token, but the former actually just calls the latter to replace `email` (saved with the access token) by an actual `user` representation. If you have other naming or implementation suggestions, I'm all ear!

And again, thank you so much for reviewing my changes! Please feel free to delay or ignore my pull requests if you don't have much time.